### PR TITLE
Add net.solarnetwork.node.setup.mobile

### DIFF
--- a/net.solarnetwork.node.setup.mobile/.classpath
+++ b/net.solarnetwork.node.setup.mobile/.classpath
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-17"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="output" path="build/eclipse"/>
+</classpath>

--- a/net.solarnetwork.node.setup.mobile/.project
+++ b/net.solarnetwork.node.setup.mobile/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>net.solarnetwork.node.setup.mobile</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+	</natures>
+</projectDescription>

--- a/net.solarnetwork.node.setup.mobile/.settings/org.eclipse.jdt.core.prefs
+++ b/net.solarnetwork.node.setup.mobile/.settings/org.eclipse.jdt.core.prefs
@@ -1,0 +1,8 @@
+eclipse.preferences.version=1
+org.eclipse.jdt.core.compiler.codegen.inlineJsrBytecode=enabled
+org.eclipse.jdt.core.compiler.codegen.targetPlatform=17
+org.eclipse.jdt.core.compiler.compliance=17
+org.eclipse.jdt.core.compiler.problem.assertIdentifier=error
+org.eclipse.jdt.core.compiler.problem.enumIdentifier=error
+org.eclipse.jdt.core.compiler.release=disabled
+org.eclipse.jdt.core.compiler.source=17

--- a/net.solarnetwork.node.setup.mobile/.settings/org.eclipse.pde.core.prefs
+++ b/net.solarnetwork.node.setup.mobile/.settings/org.eclipse.pde.core.prefs
@@ -1,0 +1,4 @@
+eclipse.preferences.version=1
+pluginProject.equinox=false
+pluginProject.extensions=false
+resolve.requirebundle=false

--- a/net.solarnetwork.node.setup.mobile/META-INF/MANIFEST.MF
+++ b/net.solarnetwork.node.setup.mobile/META-INF/MANIFEST.MF
@@ -1,0 +1,21 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: Mobile Network Setup
+Bundle-Description: System mobile (cellular/4G) network setup support.
+Bundle-SymbolicName: net.solarnetwork.node.setup.mobile
+Bundle-Version: 1.0.0
+Bundle-Vendor: SolarNetwork
+Automatic-Module-Name: net.solarnetwork.node.setup.mobile
+Bundle-RequiredExecutionEnvironment: JavaSE-17
+Import-Package: net.solarnetwork.domain;version="[3.0,4.0)",
+ net.solarnetwork.node;version="[2.0,3.0)",
+ net.solarnetwork.node.reactor;version="[2.0,3.0)",
+ net.solarnetwork.node.service.support;version="[1.0,2.0)",
+ net.solarnetwork.service.support;version="[1.0,2.0)",
+ net.solarnetwork.settings;version="[2.0,3.0)",
+ net.solarnetwork.settings.support;version="[3.0,4.0)",
+ net.solarnetwork.util;version="[2.0,3.0)",
+ org.slf4j;version="[1.7,2.0)",
+ org.springframework.beans.factory;version="[6.2,7.0)",
+ org.springframework.context;version="[6.2,7.0)",
+ org.springframework.context.support;version="[6.2,7.0)"

--- a/net.solarnetwork.node.setup.mobile/OSGI-INF/blueprint/module.xml
+++ b/net.solarnetwork.node.setup.mobile/OSGI-INF/blueprint/module.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:osgix="http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium"
+	xmlns:beans="http://www.springframework.org/schema/beans"
+	xsi:schemaLocation="
+		http://www.osgi.org/xmlns/blueprint/v1.0.0
+		http://www.osgi.org/xmlns/blueprint/v1.0.0/blueprint.xsd
+		http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium
+		http://www.eclipse.org/gemini/blueprint/schema/blueprint-compendium/gemini-blueprint-compendium.xsd
+		http://www.springframework.org/schema/beans
+		http://www.springframework.org/schema/beans/spring-beans-4.2.xsd">
+
+	<bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
+		<property name="basename" value="net.solarnetwork.node.setup.mobile.MobileConfiguration"/>
+	</bean>
+
+	<service>
+		<interfaces>
+			<value>net.solarnetwork.settings.SettingSpecifierProvider</value>
+			<value>net.solarnetwork.node.reactor.InstructionHandler</value>
+		</interfaces>
+		<service-properties>
+			<entry key="on-association" value="true"/>
+			<entry key="instruction">
+				<list>
+					<value>SystemConfigure</value>
+				</list>
+			</entry>
+		</service-properties>
+		<bean class="net.solarnetwork.node.setup.mobile.MobileConfiguration">
+			<osgix:managed-properties persistent-id="net.solarnetwork.node.setup.mobile.MobileConfiguration"
+				autowire-on-update="true" update-method="configurationChanged"/>
+			<property name="messageSource" ref="messageSource"/>
+		</bean>
+	</service>
+
+</blueprint>

--- a/net.solarnetwork.node.setup.mobile/README.md
+++ b/net.solarnetwork.node.setup.mobile/README.md
@@ -1,0 +1,85 @@
+# SolarNode Mobile Network Setup
+
+This plugin provides a configurable UI within SolarNode, and `SystemConfigure` instruction
+support, for resetting/restarting the node's mobile (cellular/4G) network connection.
+
+It is modeled on the [WiFi Setup][wifi] plugin.
+
+# Install
+
+This plugin must be manually installed, along with an OS support package that provides the `mobile`
+service script for the `solarcfg` helper. On SolarNodeOS that support is provided by the
+[`sn-mobile-mm`][sn-mobile-mm] package, which manages cellular connectivity via ModemManager and
+installs the service script to `/usr/share/solarnode/cfg.d/mobile.sh`.
+
+# Use
+
+Once installed, a new **Mobile Network** section appears on the **Settings** page on your SolarNode,
+with a **Reset Connection** toggle (the toggle returns to off after the reset is requested).
+
+# `SystemConfigure` instruction support
+
+The `SystemConfigure` instruction topic can be used to get the mobile status and to reset/restart
+the connection. The `service` parameter must be `/setup/network/mobile`. The `action` parameter
+selects the operation:
+
+| `action`              | Description                                           |
+| :-------------------- | :---------------------------------------------------- |
+| `status` (or omitted) | Return the current mobile connection status.          |
+| `reset`               | Reset (disconnect + reconnect) the mobile connection. |
+| `restart`             | Restart the mobile networking service.                |
+
+## Status result
+
+For the `status` action the `result` parameter is an object:
+
+| Property  | Type           | Description                                                         |
+| :-------- | :------------- | :------------------------------------------------------------------ |
+| `present` | `boolean`      | `true` if a mobile modem is available (and so a reset is possible). |
+| `active`  | `boolean`      | `true` if the mobile connection is currently active.                |
+| `info`    | `List<String>` | Optional detail lines (operator, access technology, signal, state). |
+
+A client can query `status` first and only offer/perform a `reset` when `present` is `true`, to
+avoid attempting a reset on a node that has no mobile modem. If the plugin is not installed on the
+node at all, the `SystemConfigure` instruction returns a not-found status instead of a result.
+
+Example `result`, expressed in JSON:
+
+```json
+{
+	"present": true,
+	"active": false,
+	"info": [
+		"operator: Spark NZ",
+		"access: lte",
+		"signal: 64%",
+		"state: registered"
+	]
+}
+```
+
+## STOMP usage
+
+Via the SolarNode STOMP setup server, after authenticating, send a frame whose `destination` is the
+service name. For example, to check whether a mobile connection is available before resetting:
+
+```
+SEND
+destination:/setup/network/mobile
+action:status
+
+^@
+```
+
+and to reset the 4G connection:
+
+```
+SEND
+destination:/setup/network/mobile
+action:reset
+
+^@
+```
+
+[wifi]: ../net.solarnetwork.node.setup.wifi/
+[sn-mobile-mm]: https://github.com/SolarNetwork/solarnode-os-packages/tree/develop/mobile-mm/debian

--- a/net.solarnetwork.node.setup.mobile/build.properties
+++ b/net.solarnetwork.node.setup.mobile/build.properties
@@ -1,0 +1,5 @@
+source.. = src/
+output.. = build/eclipse/
+bin.includes = META-INF/,\
+               .,\
+               OSGI-INF/

--- a/net.solarnetwork.node.setup.mobile/build.xml
+++ b/net.solarnetwork.node.setup.mobile/build.xml
@@ -1,0 +1,6 @@
+<project basedir=".">
+
+	<property name="dir.osgi.base" value="${basedir}/../../solarnetwork-build/solarnetwork-osgi-lib"/>
+	<import file="${dir.osgi.base}/lib-build.xml"/>
+
+</project>

--- a/net.solarnetwork.node.setup.mobile/ivy.xml
+++ b/net.solarnetwork.node.setup.mobile/ivy.xml
@@ -1,0 +1,22 @@
+<ivy-module version="2.0" xmlns:m="http://ant.apache.org/ivy/maven">
+	<info organisation="net.solarnetwork.node" module="${bundle.name}" />
+	<configurations defaultconf="compile,runtime">
+		<conf name="compile" visibility="public" description="Build dependencies"/>
+		<conf name="runtime" visibility="public" description="Runtime dependencies"/>
+		<conf name="javadoc" visibility="public" description="Javadoc documentation"/>
+		<conf name="sources"/>
+	</configurations>
+	<publications>
+		<artifact type="pom" ext="pom"/>
+		<artifact type="bundle" ext="jar"/>
+		<artifact type="javadoc" ext="jar" conf="javadoc" m:classifier="javadoc"/>
+		<artifact type="sources" ext="jar" conf="sources" m:classifier="sources"/>
+	</publications>
+	<dependencies defaultconfmapping="runtime->default(runtime);compile->default(compile)">
+       	<dependency org="net.solarnetwork.common" name="net.solarnetwork.common" rev="4.0.0"/>
+       	<dependency org="net.solarnetwork.node" name="net.solarnetwork.node" rev="4.0.0"/>
+ 		<dependency org="org.slf4j" name="slf4j-api" rev="2.0.17"/>
+		<dependency org="org.springframework" name="spring-context" rev="6.2.6"/>
+		<dependency org="org.springframework" name="spring-context-support" rev="6.2.6"/>
+	</dependencies>
+</ivy-module>

--- a/net.solarnetwork.node.setup.mobile/src/net/solarnetwork/node/setup/mobile/MobileConfiguration.java
+++ b/net.solarnetwork.node.setup.mobile/src/net/solarnetwork/node/setup/mobile/MobileConfiguration.java
@@ -78,20 +78,14 @@ import org.springframework.context.MessageSource;
  * @author elijah
  * @version 1.0
  */
-public class MobileConfiguration
-	extends BaseIdentifiable
-	implements
-		SettingSpecifierProvider,
-		SettingsChangeObserver,
-		InstructionHandler
-{
+public class MobileConfiguration extends BaseIdentifiable
+		implements SettingSpecifierProvider, SettingsChangeObserver, InstructionHandler {
 
 	/** The {@code solarcfg} service name for mobile networking. */
 	public static final String CONFIG_SERVICE = "mobile";
 
 	/** The default value for the {@code command} property. */
-	public static final String DEFAULT_COMMAND =
-		solarNodeHome() + "/bin/solarcfg";
+	public static final String DEFAULT_COMMAND = solarNodeHome() + "/bin/solarcfg";
 
 	/**
 	 * The {@literal service} instruction parameter value for mobile network
@@ -126,17 +120,15 @@ public class MobileConfiguration
 	}
 
 	@Override
-	public synchronized void configurationChanged(
-		Map<String, Object> properties
-	) {
+	public synchronized void configurationChanged(Map<String, Object> properties) {
 		// the "reset" toggle is transient; when toggled on, perform a reset and
 		// then clear the flag so the UI returns to "off" on reload
-		if (reset) {
+		if ( reset ) {
 			reset = false;
 			log.info("Mobile network reset requested via settings");
 			try {
 				executeAction(ACTION_RESET);
-			} catch (Exception e) {
+			} catch ( Exception e ) {
 				log.warn("Error resetting mobile network: {}", e.getMessage());
 			}
 		}
@@ -148,20 +140,13 @@ public class MobileConfiguration
 	}
 
 	@Override
-	public synchronized InstructionStatus processInstruction(
-		Instruction instruction
-	) {
-		if (
-			instruction == null ||
-			!handlesTopic(instruction.getTopic()) ||
-			!MOBILE_SERVICE_NAME.equals(
-				instruction.getParameterValue(PARAM_SERVICE)
-			)
-		) {
+	public synchronized InstructionStatus processInstruction(Instruction instruction) {
+		if ( instruction == null || !handlesTopic(instruction.getTopic())
+				|| !MOBILE_SERVICE_NAME.equals(instruction.getParameterValue(PARAM_SERVICE)) ) {
 			return null;
 		}
 		String action = instruction.getParameterValue(PARAM_ACTION);
-		if (action == null || action.isEmpty()) {
+		if ( action == null || action.isEmpty() ) {
 			action = ACTION_STATUS;
 		}
 		Map<String, Object> resultParams = new LinkedHashMap<>(2);
@@ -173,33 +158,21 @@ public class MobileConfiguration
 					break;
 				case ACTION_RESET:
 				case ACTION_RESTART:
-					List<String> result = executeAction(
-						action.toLowerCase(Locale.ENGLISH)
-					);
+					List<String> result = executeAction(action.toLowerCase(Locale.ENGLISH));
 					resultParams.put(PARAM_SERVICE_RESULT, result);
 					break;
 				default:
-					resultParams.put(
-						PARAM_MESSAGE,
-						getMessageSource().getMessage(
-							"error.unsupportedAction",
-							new Object[] { action },
-							"Unsupported action.",
-							Locale.getDefault()
-						)
-					);
+					resultParams.put(PARAM_MESSAGE,
+							getMessageSource().getMessage("error.unsupportedAction",
+									new Object[] { action }, "Unsupported action.",
+									Locale.getDefault()));
 					resultState = InstructionState.Declined;
 			}
-		} catch (Exception e) {
+		} catch ( Exception e ) {
 			resultParams.put(PARAM_MESSAGE, e.toString());
 			resultState = InstructionState.Declined;
 		}
-		return InstructionUtils.createStatus(
-			instruction,
-			resultState,
-			Instant.now(),
-			resultParams
-		);
+		return InstructionUtils.createStatus(instruction, resultState, Instant.now(), resultParams);
 	}
 
 	@Override
@@ -211,58 +184,35 @@ public class MobileConfiguration
 	public List<SettingSpecifier> getSettingSpecifiers() {
 		final Status status = currentStatus();
 		final List<SettingSpecifier> result = new ArrayList<>(2);
-		result.add(
-			new BasicTitleSettingSpecifier("status", statusMessage(status))
-		);
+		result.add(new BasicTitleSettingSpecifier("status", statusMessage(status)));
 
 		// Only offer the reset action when a modem is actually present, so nodes
 		// without a mobile modem do not show a confusing toggle.
-		if (status.present) {
-			result.add(
-				new BasicToggleSettingSpecifier("reset", Boolean.FALSE, true)
-			);
+		if ( status.present ) {
+			result.add(new BasicToggleSettingSpecifier("reset", Boolean.FALSE, true));
 		}
 		return result;
 	}
 
 	private String statusMessage(Status status) {
 		MessageSource messageSource = getMessageSource();
-		if (messageSource == null) {
+		if ( messageSource == null ) {
 			return "";
 		}
-		if (!status.present) {
-			return messageSource.getMessage(
-				"notSupported.label",
-				null,
-				"No mobile modem available",
-				Locale.getDefault()
-			);
+		if ( !status.present ) {
+			return messageSource.getMessage("notSupported.label", null, "No mobile modem available",
+					Locale.getDefault());
 		}
 		StringBuilder buf = new StringBuilder();
-		if (status.active) {
-			buf.append(
-				messageSource.getMessage(
-					"active.label",
-					null,
-					"Active",
-					Locale.getDefault()
-				)
-			);
+		if ( status.active ) {
+			buf.append(messageSource.getMessage("active.label", null, "Active", Locale.getDefault()));
 		} else {
 			buf.append(
-				messageSource.getMessage(
-					"inactive.label",
-					null,
-					"Inactive",
-					Locale.getDefault()
-				)
-			);
+					messageSource.getMessage("inactive.label", null, "Inactive", Locale.getDefault()));
 		}
-		if (status.info != null && !status.info.isEmpty()) {
+		if ( status.info != null && !status.info.isEmpty() ) {
 			buf.append("; ");
-			buf.append(
-				StringUtils.delimitedStringFromCollection(status.info, ", ")
-			);
+			buf.append(StringUtils.delimitedStringFromCollection(status.info, ", "));
 		}
 		return buf.toString();
 	}
@@ -325,46 +275,37 @@ public class MobileConfiguration
 		List<String> info = new ArrayList<>(4);
 		try {
 			List<String> result = executeAction(ACTION_STATUS);
-			if (result != null) {
-				for (String line : result) {
+			if ( result != null ) {
+				for ( String line : result ) {
 					int idx = line.indexOf(':');
-					if (idx < 0) {
+					if ( idx < 0 ) {
 						continue;
 					}
-					String key = line
-						.substring(0, idx)
-						.trim()
-						.toLowerCase(Locale.ENGLISH);
+					String key = line.substring(0, idx).trim().toLowerCase(Locale.ENGLISH);
 					String value = line.substring(idx + 1).trim();
-					if ("present".equals(key)) {
+					if ( "present".equals(key) ) {
 						present = "true".equalsIgnoreCase(value);
-					} else if ("active".equals(key)) {
+					} else if ( "active".equals(key) ) {
 						active = "true".equalsIgnoreCase(value);
-					} else if (!value.isEmpty()) {
+					} else if ( !value.isEmpty() ) {
 						info.add(line.trim());
 					}
 				}
 			}
-		} catch (Throwable t) {
-			log.warn(
-				"Error getting current mobile network status: {}",
-				t.getMessage()
-			);
+		} catch ( Throwable t ) {
+			log.warn("Error getting current mobile network status: {}", t.getMessage());
 		}
 		return new Status(present, active, info);
 	}
 
-	private synchronized List<String> executeAction(
-		final String action,
-		String... args
-	) {
+	private synchronized List<String> executeAction(final String action, String... args) {
 		log.debug("Executing mobile action {}", action);
 		List<String> cmd = new ArrayList<>(8);
 		cmd.add(command);
 		cmd.add(CONFIG_SERVICE);
 		cmd.add(action);
-		if (args != null && args.length > 0) {
-			for (String arg : args) {
+		if ( args != null && args.length > 0 ) {
+			for ( String arg : args ) {
 				cmd.add(arg);
 			}
 		}
@@ -372,30 +313,26 @@ public class MobileConfiguration
 		ProcessBuilder pb = new ProcessBuilder(cmd);
 		try {
 			Process pr = pb.start();
-			BufferedReader in = new BufferedReader(
-				new InputStreamReader(pr.getInputStream())
-			);
+			BufferedReader in = new BufferedReader(new InputStreamReader(pr.getInputStream()));
 			String line = null;
-			while ((line = in.readLine()) != null) {
+			while ( (line = in.readLine()) != null ) {
 				result.add(line);
 			}
 
-			BufferedReader err = new BufferedReader(
-				new InputStreamReader(pr.getErrorStream())
-			);
+			BufferedReader err = new BufferedReader(new InputStreamReader(pr.getErrorStream()));
 			StringBuilder buf = new StringBuilder();
 			line = null;
-			while ((line = err.readLine()) != null) {
-				if (buf.length() > 0) {
+			while ( (line = err.readLine()) != null ) {
+				if ( buf.length() > 0 ) {
 					buf.append('\n');
 				}
 				buf.append(line);
 			}
-			if (buf.length() > 0) {
+			if ( buf.length() > 0 ) {
 				log.error("Error executing mobile action {}: {}", action, buf);
 			}
 			return result;
-		} catch (IOException e) {
+		} catch ( IOException e ) {
 			throw new RuntimeException(e);
 		}
 	}

--- a/net.solarnetwork.node.setup.mobile/src/net/solarnetwork/node/setup/mobile/MobileConfiguration.java
+++ b/net.solarnetwork.node.setup.mobile/src/net/solarnetwork/node/setup/mobile/MobileConfiguration.java
@@ -1,0 +1,427 @@
+/* ==================================================================
+ * MobileConfiguration.java - 6/06/2026 9:00:00 AM
+ *
+ * Copyright 2026 SolarNetwork.net Dev Team
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of
+ * the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+ * 02111-1307 USA
+ * ==================================================================
+ */
+
+package net.solarnetwork.node.setup.mobile;
+
+import static net.solarnetwork.node.Constants.solarNodeHome;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import net.solarnetwork.domain.InstructionStatus.InstructionState;
+import net.solarnetwork.node.reactor.Instruction;
+import net.solarnetwork.node.reactor.InstructionHandler;
+import net.solarnetwork.node.reactor.InstructionStatus;
+import net.solarnetwork.node.reactor.InstructionUtils;
+import net.solarnetwork.node.service.support.BaseIdentifiable;
+import net.solarnetwork.settings.SettingSpecifier;
+import net.solarnetwork.settings.SettingSpecifierProvider;
+import net.solarnetwork.settings.SettingsChangeObserver;
+import net.solarnetwork.settings.support.BasicTitleSettingSpecifier;
+import net.solarnetwork.settings.support.BasicToggleSettingSpecifier;
+import net.solarnetwork.util.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.MessageSource;
+
+/**
+ * Settings provider and instruction handler for mobile (cellular/4G) network
+ * configuration.
+ *
+ * <p>
+ * This service handles the {@link InstructionHandler#TOPIC_SYSTEM_CONFIGURE}
+ * instruction topic when the {@link InstructionHandler#PARAM_SERVICE} parameter
+ * is {@link #MOBILE_SERVICE_NAME}. The {@link #PARAM_ACTION} parameter selects
+ * the operation to perform:
+ * </p>
+ *
+ * <ul>
+ * <li>{@code status} (or no action) - return the current mobile connection
+ * status</li>
+ * <li>{@code reset} - reset the mobile connection</li>
+ * <li>{@code restart} - restart the mobile networking service</li>
+ * </ul>
+ *
+ * <p>
+ * All operations are delegated to the OS-specific {@code solarcfg} helper
+ * script, invoked as {@code solarcfg mobile <action>}. The actual work is
+ * implemented by the {@code mobile} service script (for example
+ * {@code /usr/share/solarnode/cfg.d/mobile.sh}) provided by an OS support
+ * package.
+ * </p>
+ *
+ * @author elijah
+ * @version 1.0
+ */
+public class MobileConfiguration
+	extends BaseIdentifiable
+	implements
+		SettingSpecifierProvider,
+		SettingsChangeObserver,
+		InstructionHandler
+{
+
+	/** The {@code solarcfg} service name for mobile networking. */
+	public static final String CONFIG_SERVICE = "mobile";
+
+	/** The default value for the {@code command} property. */
+	public static final String DEFAULT_COMMAND =
+		solarNodeHome() + "/bin/solarcfg";
+
+	/**
+	 * The {@literal service} instruction parameter value for mobile network
+	 * configuration.
+	 */
+	public static final String MOBILE_SERVICE_NAME = "/setup/network/mobile";
+
+	/** The {@literal action} instruction parameter name. */
+	public static final String PARAM_ACTION = "action";
+
+	/** The {@literal action} parameter value to return the current status. */
+	public static final String ACTION_STATUS = "status";
+
+	/** The {@literal action} parameter value to reset the connection. */
+	public static final String ACTION_RESET = "reset";
+
+	/** The {@literal action} parameter value to restart the service. */
+	public static final String ACTION_RESTART = "restart";
+
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	private String command = DEFAULT_COMMAND;
+	private boolean reset = false;
+
+	/**
+	 * Constructor.
+	 */
+	public MobileConfiguration() {
+		super();
+		setUid("net.solarnetwork.node.setup.mobile.MobileConfiguration");
+		setDisplayName("Mobile Network");
+	}
+
+	@Override
+	public synchronized void configurationChanged(
+		Map<String, Object> properties
+	) {
+		// the "reset" toggle is transient; when toggled on, perform a reset and
+		// then clear the flag so the UI returns to "off" on reload
+		if (reset) {
+			reset = false;
+			log.info("Mobile network reset requested via settings");
+			try {
+				executeAction(ACTION_RESET);
+			} catch (Exception e) {
+				log.warn("Error resetting mobile network: {}", e.getMessage());
+			}
+		}
+	}
+
+	@Override
+	public boolean handlesTopic(String topic) {
+		return InstructionHandler.TOPIC_SYSTEM_CONFIGURE.equals(topic);
+	}
+
+	@Override
+	public synchronized InstructionStatus processInstruction(
+		Instruction instruction
+	) {
+		if (
+			instruction == null ||
+			!handlesTopic(instruction.getTopic()) ||
+			!MOBILE_SERVICE_NAME.equals(
+				instruction.getParameterValue(PARAM_SERVICE)
+			)
+		) {
+			return null;
+		}
+		String action = instruction.getParameterValue(PARAM_ACTION);
+		if (action == null || action.isEmpty()) {
+			action = ACTION_STATUS;
+		}
+		Map<String, Object> resultParams = new LinkedHashMap<>(2);
+		InstructionState resultState = InstructionState.Completed;
+		try {
+			switch (action.toLowerCase(Locale.ENGLISH)) {
+				case ACTION_STATUS:
+					resultParams.put(PARAM_SERVICE_RESULT, currentStatus());
+					break;
+				case ACTION_RESET:
+				case ACTION_RESTART:
+					List<String> result = executeAction(
+						action.toLowerCase(Locale.ENGLISH)
+					);
+					resultParams.put(PARAM_SERVICE_RESULT, result);
+					break;
+				default:
+					resultParams.put(
+						PARAM_MESSAGE,
+						getMessageSource().getMessage(
+							"error.unsupportedAction",
+							new Object[] { action },
+							"Unsupported action.",
+							Locale.getDefault()
+						)
+					);
+					resultState = InstructionState.Declined;
+			}
+		} catch (Exception e) {
+			resultParams.put(PARAM_MESSAGE, e.toString());
+			resultState = InstructionState.Declined;
+		}
+		return InstructionUtils.createStatus(
+			instruction,
+			resultState,
+			Instant.now(),
+			resultParams
+		);
+	}
+
+	@Override
+	public String getSettingUid() {
+		return getUid();
+	}
+
+	@Override
+	public List<SettingSpecifier> getSettingSpecifiers() {
+		final Status status = currentStatus();
+		final List<SettingSpecifier> result = new ArrayList<>(2);
+		result.add(
+			new BasicTitleSettingSpecifier("status", statusMessage(status))
+		);
+
+		// Only offer the reset action when a modem is actually present, so nodes
+		// without a mobile modem do not show a confusing toggle.
+		if (status.present) {
+			result.add(
+				new BasicToggleSettingSpecifier("reset", Boolean.FALSE, true)
+			);
+		}
+		return result;
+	}
+
+	private String statusMessage(Status status) {
+		MessageSource messageSource = getMessageSource();
+		if (messageSource == null) {
+			return "";
+		}
+		if (!status.present) {
+			return messageSource.getMessage(
+				"notSupported.label",
+				null,
+				"No mobile modem available",
+				Locale.getDefault()
+			);
+		}
+		StringBuilder buf = new StringBuilder();
+		if (status.active) {
+			buf.append(
+				messageSource.getMessage(
+					"active.label",
+					null,
+					"Active",
+					Locale.getDefault()
+				)
+			);
+		} else {
+			buf.append(
+				messageSource.getMessage(
+					"inactive.label",
+					null,
+					"Inactive",
+					Locale.getDefault()
+				)
+			);
+		}
+		if (status.info != null && !status.info.isEmpty()) {
+			buf.append("; ");
+			buf.append(
+				StringUtils.delimitedStringFromCollection(status.info, ", ")
+			);
+		}
+		return buf.toString();
+	}
+
+	/**
+	 * A mobile connection status.
+	 */
+	public static final class Status {
+
+		private final boolean present;
+		private final boolean active;
+		private final List<String> info;
+
+		private Status(boolean present, boolean active, List<String> info) {
+			super();
+			this.present = present;
+			this.active = active;
+			this.info = info;
+		}
+
+		/**
+		 * Get the modem presence status.
+		 *
+		 * <p>
+		 * This indicates whether a mobile modem is available on the node at all,
+		 * and thus whether a reset can be performed. A client (such as the mobile
+		 * app) can use this to decide whether to offer a reset action, rather than
+		 * attempting a reset that has nothing to act on.
+		 * </p>
+		 *
+		 * @return {@literal true} if a mobile modem is present
+		 */
+		public boolean isPresent() {
+			return present;
+		}
+
+		/**
+		 * Get the active status.
+		 *
+		 * @return {@literal true} if the mobile connection is currently active
+		 */
+		public boolean isActive() {
+			return active;
+		}
+
+		/**
+		 * Get additional status detail lines (such as operator, access
+		 * technology, or signal), as emitted by the helper script.
+		 *
+		 * @return the status detail lines
+		 */
+		public List<String> getInfo() {
+			return info;
+		}
+	}
+
+	private Status currentStatus() {
+		boolean present = false;
+		boolean active = false;
+		List<String> info = new ArrayList<>(4);
+		try {
+			List<String> result = executeAction(ACTION_STATUS);
+			if (result != null) {
+				for (String line : result) {
+					int idx = line.indexOf(':');
+					if (idx < 0) {
+						continue;
+					}
+					String key = line
+						.substring(0, idx)
+						.trim()
+						.toLowerCase(Locale.ENGLISH);
+					String value = line.substring(idx + 1).trim();
+					if ("present".equals(key)) {
+						present = "true".equalsIgnoreCase(value);
+					} else if ("active".equals(key)) {
+						active = "true".equalsIgnoreCase(value);
+					} else if (!value.isEmpty()) {
+						info.add(line.trim());
+					}
+				}
+			}
+		} catch (Throwable t) {
+			log.warn(
+				"Error getting current mobile network status: {}",
+				t.getMessage()
+			);
+		}
+		return new Status(present, active, info);
+	}
+
+	private synchronized List<String> executeAction(
+		final String action,
+		String... args
+	) {
+		log.debug("Executing mobile action {}", action);
+		List<String> cmd = new ArrayList<>(8);
+		cmd.add(command);
+		cmd.add(CONFIG_SERVICE);
+		cmd.add(action);
+		if (args != null && args.length > 0) {
+			for (String arg : args) {
+				cmd.add(arg);
+			}
+		}
+		List<String> result = new ArrayList<>(8);
+		ProcessBuilder pb = new ProcessBuilder(cmd);
+		try {
+			Process pr = pb.start();
+			BufferedReader in = new BufferedReader(
+				new InputStreamReader(pr.getInputStream())
+			);
+			String line = null;
+			while ((line = in.readLine()) != null) {
+				result.add(line);
+			}
+
+			BufferedReader err = new BufferedReader(
+				new InputStreamReader(pr.getErrorStream())
+			);
+			StringBuilder buf = new StringBuilder();
+			line = null;
+			while ((line = err.readLine()) != null) {
+				if (buf.length() > 0) {
+					buf.append('\n');
+				}
+				buf.append(line);
+			}
+			if (buf.length() > 0) {
+				log.error("Error executing mobile action {}: {}", action, buf);
+			}
+			return result;
+		} catch (IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	/**
+	 * Set the command to use.
+	 *
+	 * @param command
+	 *        the command to set; defaults to {@link #DEFAULT_COMMAND}
+	 */
+	public void setCommand(String command) {
+		this.command = command;
+	}
+
+	/**
+	 * Set the reset toggle.
+	 *
+	 * <p>
+	 * This is a transient setting: when set to {@literal true} a mobile network
+	 * reset is performed and the value is reset to {@literal false}.
+	 * </p>
+	 *
+	 * @param reset
+	 *        {@literal true} to trigger a reset
+	 */
+	public void setReset(boolean reset) {
+		this.reset = reset;
+	}
+}

--- a/net.solarnetwork.node.setup.mobile/src/net/solarnetwork/node/setup/mobile/MobileConfiguration.properties
+++ b/net.solarnetwork.node.setup.mobile/src/net/solarnetwork/node/setup/mobile/MobileConfiguration.properties
@@ -1,0 +1,18 @@
+title = Mobile Network
+desc = Configure and reset the node mobile (cellular/4G) network connection.
+
+command.key = Command
+command.desc = The <code>solarcfg</code> system command to execute.
+
+status.key = Status
+status.desc = The current mobile connection status and associated detail.
+
+reset.key = Reset Connection
+reset.desc = Toggle on to reset the mobile (4G) connection. The toggle returns to off once the \
+	reset has been requested.
+
+active.label = Active
+inactive.label = Inactive
+notSupported.label = No mobile modem available
+
+error.unsupportedAction = Unsupported mobile action ''{0}''. Supported actions are 'status', 'reset', and 'restart'.

--- a/net.solarnetwork.node.setup.wifi/README.md
+++ b/net.solarnetwork.node.setup.wifi/README.md
@@ -62,4 +62,4 @@ parameter is not provided, it will remain unchanged from its current value.
 | `ssid`     | The name of the WiFi network to connect to. |
 | `password` | The WiFi password to use. |
 
-[sn-wifi]: https://github.com/SolarNetworkFoundation/solarnetwork-ops/tree/master/packages/wifi/debian
+[sn-wifi]: https://github.com/SolarNetwork/solarnode-os-packages/tree/master/wifi/debian


### PR DESCRIPTION
Adds a basic plugin for resetting/restarting the node's mobile (cellular/4G) network connection. It comes with a UI integration and `SystemConfigure` support. I used the wifi plugin as a basis for constructing this.

Primarily made for the STOMP server, but could be used generally through the web dashboard too.

You can query `status` first to see if there is support on the device, since it's entirely possible a node may not have the hardware.

Leaving as a draft for now since I haven't had a good opportunity to really test this well. Will update this when I have had a good play around.

- Requires https://github.com/SolarNetwork/solarnode-os-packages/pull/7